### PR TITLE
finetuning

### DIFF
--- a/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
+++ b/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
@@ -1,102 +1,114 @@
 $(document).ready(function() {
 
-  $("body").append(`<div id="json-input-modal" class="modal fade" aria-labelledby="JsonInputModal" role="dialog">
-    <div class="modal-dialog modal-lg">
-      <div id="json-input-modal-content" class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h4 class="modal-title">JSON Input</h4>
+  if ($('.json-input-bootstrap-rails').length > 0) {
+    $("body").append(`<div id="json-input-modal" class="modal fade" aria-labelledby="JsonInputModal" role="dialog">
+      <div class="modal-dialog modal-lg">
+        <div id="json-input-modal-content" class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h4 id="json-title" class="modal-title">JSON Input</h4>
+          </div>
+          <form id="json-form">
+            <div id="json-rows" class="modal-body">
+              <div class="row json-header-row">
+                <label id="json-header-key" class="control-label col-xs-5">key</label>
+                <label class="control-label col-xs-1">:</label>
+                <label id="json-header-value" class="control-label col-xs-5">value</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <div class="row">
+                <div class="col-xs-11"></div>
+                <div class="btn-area col-xs-1"><button id="add-row" type="button" class="btn btn-success">+</button></div>
+              </div>
+            </div>
+          </form>
         </div>
-        <form id="json-form">
-          <div id="json-rows" class="modal-body">
-            <div class="row json-header-row">
-              <label class="control-label col-xs-5">key</label>
-              <label class="control-label col-xs-1">:</label>
-              <label class="control-label col-xs-5">value</label>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <div class="row">
-              <div class="col-xs-11"></div>
-              <div class="btn-area col-xs-1"><button id="add-row" type="button" class="btn btn-success">+</button></div>
-            </div>
-          </div>
-        </form>
       </div>
-    </div>
-  </div>`)
+    </div>`)
 
-  var text_area = $(".json-input-bootstrap-rails")
-  var modal = $("#json-input-modal")
-  var save_button = $("#save-button")
-  var add_row_button = $("#add-row")
-  var json_form = $("#json-form")
-  var json_rows = $("#json-rows")
+    var modal = $("#json-input-modal")
+    var json_form = $("#json-form")
+    var json_rows = $("#json-rows")
 
-  var new_row = `<div class="row json-row">
-    <div class="form-group">
-      <div class="key-field col-xs-5"><input class="form-control"></div>
-      <div class="colon-holder col-xs-1"><span>:</span></div>
-      <div class="value-field col-xs-5"><input class="form-control"></div>
-      <div class="delete-area btn-area col-xs-1">
-        <button class="delete-button btn btn-danger" type="button">X</button>
+    var new_row = `<div class="row json-row">
+      <div class="form-group">
+        <div class="key-field col-xs-5"><input class="form-control"></div>
+        <div class="colon-field col-xs-1"><span>:</span></div>
+        <div class="value-field col-xs-5"><input class="form-control"></div>
+        <div class="delete-area btn-area col-xs-1">
+          <button class="delete-button btn btn-danger" type="button">x</button>
+        </div>
       </div>
-    </div>
-  </div>`
+    </div>`
 
-  text_area.click(function() {
-    modal.modal('show');
-    
-    json_form.attr("data", this.id)
-    var current_text = ""
+    $(document).on('click', ".json-input-bootstrap-rails", function(e) {
+      json_form.attr("data", this.id)
+      var text_area = $(e.target)
+      var current_text = ""
+      var keyLabel = text_area.attr('data-key-label')
+      if (typeof keyLabel !== typeof undefined && keyLabel !== false) {
+        $('#json-header-key').text(keyLabel);
+      }
+      var valueLabel = text_area.attr('data-value-label')
+      if (typeof valueLabel !== typeof undefined && valueLabel !== false){
+        $('#json-header-value').text(valueLabel);
+      }
+      var title = text_area.attr('data-title')
+      if (typeof title !== typeof undefined && title !== false) {
+        $('#json-title').text(title);
+      } else {
+        $('#json-title').text(text_area.attr('name'));
+      }
 
-    if (this.value == "") {
-      $(".json-row").remove()
-      json_rows.append(new_row)
-    } else {
-      current_text = JSON.parse(this.value)
-      $(".json-row").remove()
-      $.each(current_text, function(key, val){
-        json_rows.append(`<div class="row json-row">
-          <div class="form-group">
-            <div class="key-field col-xs-5">
-              <input class="key-data form-control" value="` + key + `">
+      if (this.value == "") {
+        $(".json-row").remove()
+        json_rows.append(new_row)
+      } else {
+        current_text = JSON.parse(this.value)
+        $(".json-row").remove()
+        $.each(current_text, function(key, val){
+          json_rows.append(`<div class="row json-row">
+            <div class="form-group">
+              <div class="key-field col-xs-5">
+                <input class="key-data form-control" value="` + key + `">
+              </div>
+              <div class="colon-holder col-xs-1"><span>:</span></div>
+              <div class="value-field col-xs-5">
+                <input class="value-data form-control" value="` + val +`">
+              </div>
+              <div class="delete-area btn-area col-xs-1">
+                <button class="delete-button btn btn-danger" type="button">x</button>
+              </div>
             </div>
-            <div class="colon-holder col-xs-1"><span>:</span></div>
-            <div class="value-field col-xs-5">
-              <input class="value-data form-control" value="` + val +`">
-            </div>
-            <div class="delete-area btn-area col-xs-1">
-              <button class="delete-button btn btn-danger" type="button">X</button>
-            </div>
-          </div>
-        </div>`)
-      })
-      json_rows.append(new_row)
-    }
-    modal.modal('show');
-  })
+          </div>`)
+        })
+        json_rows.append(new_row)
+      }
+      modal.modal('show');
+    })
 
-  add_row_button.click(function(){
-    $("#json-rows").append(new_row);
-  });
+    $(document).on('click', '#json-input-modal #add-row', function(){
+      $("#json-rows").append(new_row);
+    });
 
-  json_form.on('click','.delete-button',function() {
-    this.parentElement.parentElement.remove()
-  });
+    $(document).on('click', '#json-input-modal .delete-button', function() {
+      this.parentElement.parentElement.remove()
+    });
 
-  modal.on('hidden.bs.modal', function () {
-    var values = []
-    var pairs = {}
-    $("#json-form input").each(function(index, data){ values.push($(this).val()) })
-    values = values.filter(function(n){ return n != "" })
-    for (var i=0; i < values.length; i = i+2) {
-      pairs[values[i]] = values[i+1]
-    }
-    var json = JSON.stringify(pairs)
-    $('[id='+ json_form.attr("data") +']').val(json)
-    modal.modal('hide');
-  })
+    $(document).on('hidden.bs.modal', '#json-input-modal', function () {
+      var values = []
+      var pairs = {}
+      $("#json-form input").each(function(index, data){ values.push($(this).val()) })
+      values = values.filter(function(n){ return n != "" })
+      for (var i=0; i < values.length; i = i+2) {
+        pairs[values[i]] = values[i+1]
+      }
+      var json = JSON.stringify(pairs)
+      $('[id='+ json_form.attr("data") +']').val(json)
+      modal.modal('hide');
+    })
+  }
 });

--- a/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
+++ b/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
@@ -1,55 +1,54 @@
 $(document).ready(function() {
 
-  $("body").append(`<div id="json-input-modal" class="modal-dialog modal-lg">
-    <div id="json-input-modal-content" class="modal-content">
-      <form id="json-form">
-        <div id="json-rows">
-          <div class="row json-header-row">
-            <div class="key-label col-xs-5">
-              <span>KEY</span>
-            </div>
-            <div class="colon-label col-xs-1">
-              <span>:</span>
-            </div>
-            <div class="value-label col-xs-5">
-              <span>VALUE</span>
+  $("body").append(`<div id="json-input-modal" class="modal fade" aria-labelledby="JsonInputModal" role="dialog">
+    <div class="modal-dialog modal-lg">
+      <div id="json-input-modal-content" class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">JSON Input</h4>
+        </div>
+        <form id="json-form">
+          <div id="json-rows" class="modal-body">
+            <div class="row json-header-row">
+              <label class="control-label col-xs-5">key</label>
+              <label class="control-label col-xs-1">:</label>
+              <label class="control-label col-xs-5">value</label>
             </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button id="save-button" type="submit" class="btn btn-success">Save</button>
-          <button id="cancel-button" type="button" class="btn btn-success">Cancel</button>
-          <button id="add-row" type="button" class="btn btn-success">Add a Row</button>
-        </div>
-      </form>
+          <div class="modal-footer">
+            <div class="row">
+              <div class="col-xs-11"></div>
+              <div class="btn-area col-xs-1"><button id="add-row" type="button" class="btn btn-success">+</button></div>
+            </div>
+          </div>
+        </form>
+      </div>
     </div>
   </div>`)
 
   var text_area = $(".json-input-bootstrap-rails")
   var modal = $("#json-input-modal")
-  var cancel_button = $("#cancel-button")
   var save_button = $("#save-button")
   var add_row_button = $("#add-row")
   var json_form = $("#json-form")
   var json_rows = $("#json-rows")
 
   var new_row = `<div class="row json-row">
-    <div class="key-field col-xs-5">
-      <input class="form-control">
-    </div>
-    <div class="colon-holder col-xs-1">
-      <span>:</span>
-    </div>
-    <div class="value-field col-xs-5">
-      <input class="form-control">
-    </div>
-    <div class="delete-area col-xs-1">
-      <button class="delete-button btn" type="button">X</button>
+    <div class="form-group">
+      <div class="key-field col-xs-5"><input class="form-control"></div>
+      <div class="colon-holder col-xs-1"><span>:</span></div>
+      <div class="value-field col-xs-5"><input class="form-control"></div>
+      <div class="delete-area btn-area col-xs-1">
+        <button class="delete-button btn btn-danger" type="button">X</button>
+      </div>
     </div>
   </div>`
 
-
   text_area.click(function() {
+    modal.modal('show');
+    
     json_form.attr("data", this.id)
     var current_text = ""
 
@@ -61,26 +60,23 @@ $(document).ready(function() {
       $(".json-row").remove()
       $.each(current_text, function(key, val){
         json_rows.append(`<div class="row json-row">
-          <div class="key-field col-xs-5">
-            <input class="key-data form-control" value="` + key + `">
-          </div>
-          <div class="colon-holder col-xs-1">
-            <span>:</span>
-          </div>
-          <div class="value-field col-xs-5">
-            <input class="value-data form-control" value="` + val +`">
-          </div>
-          <div class="delete-area col-xs-1">
-            <button class="delete-button btn" type="button">X</button>
+          <div class="form-group">
+            <div class="key-field col-xs-5">
+              <input class="key-data form-control" value="` + key + `">
+            </div>
+            <div class="colon-holder col-xs-1"><span>:</span></div>
+            <div class="value-field col-xs-5">
+              <input class="value-data form-control" value="` + val +`">
+            </div>
+            <div class="delete-area btn-area col-xs-1">
+              <button class="delete-button btn btn-danger" type="button">X</button>
+            </div>
           </div>
         </div>`)
       })
+      json_rows.append(new_row)
     }
-    modal.css("display", "block")
-  })
-
-  cancel_button.click(function() {
-    modal.css("display", "none")
+    modal.modal('show');
   })
 
   add_row_button.click(function(){
@@ -91,18 +87,16 @@ $(document).ready(function() {
     this.parentElement.parentElement.remove()
   });
 
-  json_form.submit(function(event) {
-    event.preventDefault()
+  modal.on('hidden.bs.modal', function () {
     var values = []
     var pairs = {}
-    $.each(event.target.elements, function(index){values.push(event.target.elements[index].value)})
+    $("#json-form input").each(function(index, data){ values.push($(this).val()) })
     values = values.filter(function(n){ return n != "" })
-    for (var i=0; i<values.length; i = i+2) {
+    for (var i=0; i < values.length; i = i+2) {
       pairs[values[i]] = values[i+1]
     }
-    var final = JSON.stringify(pairs)
-    $('[id='+ this.attributes.data.value +']').val(final)
-    modal.css("display", "none")
+    var json = JSON.stringify(pairs)
+    $('[id='+ json_form.attr("data") +']').val(json)
+    modal.modal('hide');
   })
-
 });

--- a/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
+++ b/json_input_bootstrap_rails/app/assets/javascripts/json_input_bootstrap_rails.js
@@ -1,62 +1,27 @@
 $(document).ready(function() {
 
   if ($('.json-input-bootstrap-rails').length > 0) {
-    $("body").append(`<div id="json-input-modal" class="modal fade" aria-labelledby="JsonInputModal" role="dialog">
-      <div class="modal-dialog modal-lg">
-        <div id="json-input-modal-content" class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-            <h4 id="json-title" class="modal-title">JSON Input</h4>
-          </div>
-          <form id="json-form">
-            <div id="json-rows" class="modal-body">
-              <div class="row json-header-row">
-                <label id="json-header-key" class="control-label col-xs-5">key</label>
-                <label class="control-label col-xs-1">:</label>
-                <label id="json-header-value" class="control-label col-xs-5">value</label>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <div class="row">
-                <div class="col-xs-11"></div>
-                <div class="btn-area col-xs-1"><button id="add-row" type="button" class="btn btn-success">+</button></div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>`)
+    $("body").append('<div id="json-input-modal" class="modal fade" aria-labelledby="JsonInputModal" role="dialog"><div class="modal-dialog modal-lg"><div id="json-input-modal-content" class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><h4 id="json-title" class="modal-title">JSON Input</h4></div><form id="json-form"><div id="json-rows" class="modal-body"><div class="row json-header-row"><label id="json-header-key" class="control-label col-xs-5">key</label><label class="control-label col-xs-1">:</label><label id="json-header-value" class="control-label col-xs-5">value</label></div></div><div class="modal-footer"><div class="row"><div class="col-xs-11"></div><div class="btn-area col-xs-1"><button id="add-row" type="button" class="btn btn-success">+</button></div></div></div></form></div></div></div>');
 
-    var modal = $("#json-input-modal")
-    var json_form = $("#json-form")
-    var json_rows = $("#json-rows")
+    var modal = $("#json-input-modal");
+    var json_form = $("#json-form");
+    var json_rows = $("#json-rows");
 
-    var new_row = `<div class="row json-row">
-      <div class="form-group">
-        <div class="key-field col-xs-5"><input class="form-control"></div>
-        <div class="colon-field col-xs-1"><span>:</span></div>
-        <div class="value-field col-xs-5"><input class="form-control"></div>
-        <div class="delete-area btn-area col-xs-1">
-          <button class="delete-button btn btn-danger" type="button">x</button>
-        </div>
-      </div>
-    </div>`
+    var new_row = '<div class="row json-row"><div class="form-group"><div class="key-field col-xs-5"><input class="form-control"></div><div class="colon-field col-xs-1"><span>:</span></div><div class="value-field col-xs-5"><input class="form-control"></div><div class="delete-area btn-area col-xs-1"><button class="delete-button btn btn-danger" type="button">x</button></div></div></div>';
 
     $(document).on('click', ".json-input-bootstrap-rails", function(e) {
-      json_form.attr("data", this.id)
-      var text_area = $(e.target)
-      var current_text = ""
-      var keyLabel = text_area.attr('data-key-label')
+      json_form.attr("data", this.id);
+      var text_area = $(e.target);
+      var current_text = "";
+      var keyLabel = text_area.attr('data-key-label');
       if (typeof keyLabel !== typeof undefined && keyLabel !== false) {
         $('#json-header-key').text(keyLabel);
       }
-      var valueLabel = text_area.attr('data-value-label')
+      var valueLabel = text_area.attr('data-value-label');
       if (typeof valueLabel !== typeof undefined && valueLabel !== false){
         $('#json-header-value').text(valueLabel);
       }
-      var title = text_area.attr('data-title')
+      var title = text_area.attr('data-title');
       if (typeof title !== typeof undefined && title !== false) {
         $('#json-title').text(title);
       } else {
@@ -64,28 +29,15 @@ $(document).ready(function() {
       }
 
       if (this.value == "") {
-        $(".json-row").remove()
-        json_rows.append(new_row)
+        $(".json-row").remove();
+        json_rows.append(new_row);
       } else {
-        current_text = JSON.parse(this.value)
-        $(".json-row").remove()
+        current_text = JSON.parse(this.value);
+        $(".json-row").remove();
         $.each(current_text, function(key, val){
-          json_rows.append(`<div class="row json-row">
-            <div class="form-group">
-              <div class="key-field col-xs-5">
-                <input class="key-data form-control" value="` + key + `">
-              </div>
-              <div class="colon-holder col-xs-1"><span>:</span></div>
-              <div class="value-field col-xs-5">
-                <input class="value-data form-control" value="` + val +`">
-              </div>
-              <div class="delete-area btn-area col-xs-1">
-                <button class="delete-button btn btn-danger" type="button">x</button>
-              </div>
-            </div>
-          </div>`)
+          json_rows.append('<div class="row json-row"><div class="form-group"><div class="key-field col-xs-5"><input class="key-data form-control" value="' + key + '"></div><div class="colon-holder col-xs-1"><span>:</span></div><div class="value-field col-xs-5"><input class="value-data form-control" value="' + val + '"></div><div class="delete-area btn-area col-xs-1"><button class="delete-button btn btn-danger" type="button">x</button></div></div></div>');
         })
-        json_rows.append(new_row)
+        json_rows.append(new_row);
       }
       modal.modal('show');
     })
@@ -95,19 +47,19 @@ $(document).ready(function() {
     });
 
     $(document).on('click', '#json-input-modal .delete-button', function() {
-      this.parentElement.parentElement.remove()
+      this.parentElement.parentElement.remove();
     });
 
     $(document).on('hidden.bs.modal', '#json-input-modal', function () {
-      var values = []
-      var pairs = {}
-      $("#json-form input").each(function(index, data){ values.push($(this).val()) })
-      values = values.filter(function(n){ return n != "" })
+      var values = [];
+      var pairs = {};
+      $("#json-form input").each(function(index, data){ values.push($(this).val()) });
+      values = values.filter(function(n){ return n != "" });
       for (var i=0; i < values.length; i = i+2) {
-        pairs[values[i]] = values[i+1]
+        pairs[values[i]] = values[i+1];
       }
-      var json = JSON.stringify(pairs)
-      $('[id='+ json_form.attr("data") +']').val(json)
+      var json = JSON.stringify(pairs);
+      $('[id='+ json_form.attr("data") +']').val(json);
       modal.modal('hide');
     })
   }

--- a/json_input_bootstrap_rails/app/assets/stylesheets/json_input_bootstrap_rails.css
+++ b/json_input_bootstrap_rails/app/assets/stylesheets/json_input_bootstrap_rails.css
@@ -1,4 +1,4 @@
-#json-input-modal label {
+#json-input-modal label, #json-input-modal .colon-field {
   text-align: center;
 }
 

--- a/json_input_bootstrap_rails/app/assets/stylesheets/json_input_bootstrap_rails.css
+++ b/json_input_bootstrap_rails/app/assets/stylesheets/json_input_bootstrap_rails.css
@@ -1,38 +1,11 @@
-#json-input-modal {
-  display: none;
-  position: fixed;
-  z-index: 1;
-  left: 0;
-  top: 0;
+#json-input-modal label {
+  text-align: center;
+}
+
+#json-input-modal .json-row {
+  margin-bottom: 20px;
+}
+
+#json-input-modal .btn-area button {
   width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgb(0,0,0);
-  background-color: rgba(0,0,0,0.4);
-}
-
-#json-input-modal-content {
-    background-color: #fefefe;
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 50%;
-}
-
-.key-label, .colon-label, .colon-holder, .value-label {
-  text-align: center;
-  font-weight: bold;
-}
-
-.key-field, .colon-holder, .value-field {
-  text-align: center;
-}
-
-.modal-footer button {
-  float: right;
-  margin-right: 10px;
-}
-
-.json-row {
-  margin-bottom: 5px;
 }


### PR DESCRIPTION
Add more default Bootstrap & Modal classes and therefore could remove some CSS where that behaviour was C&P'ed. also there's a default way for triggering a Modal and I applied this. Had to change backtick style template interpolation to single line strings, ugly but compatible with older browsers and asset precompilation this way.

Also a bit of optical finetuning.

Only functional changes:

- display an empty key value pair initially- 
- remove "Save" button in favor of saving when closing the modal
- customizeable labels